### PR TITLE
Remove duplicated edge_canry

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Windows / Linux / MacOS
 
 #### Browser
 
-chrome_canary / chrome_dev / chrome_beta / chrome_stable / edge_canary
+chrome_canary / chrome_dev / chrome_beta / chrome_stable / edge_canary / edge_dev / edge_beta / edge_stable
+
+edge_canary is not available on Linux.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Windows / Linux / MacOS
 
 #### Browser
 
-chrome_canary / chrome_beta / chrome_dev / chrome_stable / edge_canary
+chrome_canary / chrome_dev / chrome_beta / chrome_stable / edge_canary
 
 ## Install
 

--- a/generate-config.js
+++ b/generate-config.js
@@ -284,7 +284,7 @@ Options:
 `;
 
 const validDevices = ["cpu", "npu", "gpu"];
-const validBrowsers = ["chrome_canary", "edge_canary", "chrome_beta", "chrome_dev", "chrome_stable", "edge_canary"];
+const validBrowsers = ["chrome_canary", "chrome_dev", "chrome_beta", "chrome_stable", "edge_canary"];
 
 if (process.argv.length === 3 && (process.argv[2] === "--help" || process.argv[2] === "-h")) {
   console.log(HELP_MESSAGE);


### PR DESCRIPTION
@NingW101 PTAL, do we have any plan to support edge_dev and edge_beta, even edge_stable? 

https://github.com/webmachinelearning/webnn-samples-test-framework/blob/main/src/utils/util.js#L131

```
case "edge_canary":

 if (deviceInfo.platform === "linux") {
        browserExeName = "microsoft-edge-dev";
```

Is it correct?