### PR TITLE
Use liquidjs html template language

### DIFF
--- a/env.example.json
+++ b/env.example.json
@@ -13,7 +13,10 @@
       "auth": false
     },
     "from": "",
-    "to": []
+    "to": [],
+    "header": "Test completed, please check the details below:",
+    "footer": null,
+    "signature": "WebNN Team"
   },
   "scp": {
     "target": "user@host:/path/to/target"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "canvas": "^3.0.1",
     "dayjs": "^1.11.10",
+    "liquidjs": "^10.21.1",
     "lodash": "^4.17.21",
     "nodemailer": "^6.9.13",
     "prettier": "^3.2.5",

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
 const _ = require("lodash");
-const util = require("./utils/util.js");
-const { generateTestSummaryMd, report, scpUpload } = require("./utils/report.js");
+
 const config = require("../config.json");
 const env = require("../env.json");
-const path = require("path");
+const util = require("./utils/util.js");
+const { renderResultsAsHTML, report, scpUpload } = require("./utils/report.js");
 
 const SAMPLES_NAME_JS_PATH_MAPPING = {
   imageClassification: __dirname + "/cases/samples/image-classification.js",
@@ -117,7 +120,9 @@ const main = async () => {
       targetName: path.basename(jsonPath).substring(0, 8) + ".json"
     });
 
-    generateTestSummaryMd(jsonPath);
+    const htmlPath = jsonPath.split(".")[0] + ".html";
+    fs.writeFileSync(htmlPath, await renderResultsAsHTML(require(jsonPath)));
+    console.log(`Test results have been saved to ${jsonPath} and ${htmlPath}`);
 
     if (env.env === "production") {
       await report(jsonPath);

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -1,44 +1,17 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const os = require("os");
-const nodemailer = require("nodemailer");
-const util = require("./util.js");
-const env = require("../../env.json");
 const path = require("path");
-const config = require("../../config.json");
 
-function formatResultsAsHTMLTable(data) {
+const { Liquid } = require("liquidjs");
+const nodemailer = require("nodemailer");
+
+const env = require("../../env.json");
+const config = require("../../config.json");
+const util = require("./util.js");
+
+async function renderResultsAsHTML(data) {
   const failuresSamples = [];
-  const deviceInfo = [];
-  const resultObj = {
-    html: {
-      total: 0,
-      failed: 0,
-      deviceInfoTable: "",
-      performanceDataTable: "",
-      memoryDataTable: "",
-      failuresTable: ""
-    },
-    md: {
-      total: 0,
-      failed: 0,
-      deviceInfoMdTable: "",
-      performanceDataMdTable: "",
-      memoryDataMdTable: "",
-      failuresMdTable: "",
-      testSummaryMdTable: ""
-    }
-  };
-  const metrics = [
-    "inferenceTime",
-    "processTime",
-    "first",
-    "average",
-    "median",
-    "best",
-    "tokensPerSecond",
-    "throughput"
-  ];
 
   const memoryMetrics = [
     "privateMemoryRendererBefore",
@@ -49,420 +22,96 @@ function formatResultsAsHTMLTable(data) {
     "privateMemoryGpuPeak"
   ];
 
-  const performanceData = {};
   const memoryConsumptionData = {};
   const testSummaryResults = [];
-
   let totalCaseCount = 0;
 
-  function traverse(obj, path = "") {
-    if (obj && typeof obj === "object") {
-      for (const key in obj) {
-        const currentPath = path ? `${path}-${key}` : key;
-        if (currentPath.startsWith("samples") || currentPath.startsWith("developerPreview")) {
-          if (key === "error") {
-            // make each sample case has error attribute account
-            totalCaseCount++;
-            const variable = currentPath.replace(/-error/g, "");
-            // if error is not empty
-            if (obj[key]) {
-              failuresSamples.push({ variable, error: obj[key] });
-              testSummaryResults.push({ variable, status: "fail" });
-            } else {
-              // initialize the samples that do not have performance results
-              // code editor & notepad
-              if (!performanceData[variable]) {
-                performanceData[variable] = {};
-              }
-              testSummaryResults.push({ variable, status: "pass" });
-            }
-          }
-          // collect performance data
-          else if (metrics.includes(key) && !obj["error"]) {
-            // remove useless attribute
-            const variable = currentPath.replace(`-${key}`, "");
-            if (!performanceData[variable]) {
-              performanceData[variable] = {};
-            }
-            performanceData[variable][key] = obj[key];
-          }
-          // collect memory data
-          else if (memoryMetrics.includes(key) && !obj["error"]) {
-            // remove useless attribute
-            const variable = currentPath.replace(`-${key}`, "");
-            if (!memoryConsumptionData[variable]) {
-              memoryConsumptionData[variable] = {};
-            }
-            memoryConsumptionData[variable][key] = obj[key];
-          } else {
-            traverse(obj[key], currentPath);
-          }
-        } else if (key !== "deviceInfo" && currentPath.includes("deviceInfo")) {
-          if (obj[key]) {
-            deviceInfo.push({ category: key, detail: obj[key] });
-          }
+  function traverse(obj, path = [], result) {
+    for (const key in obj) {
+      if (key === "error") {
+        // make each sample case has error attribute account
+        totalCaseCount++;
+        const variable = path.join("-");
+        // if error is not empty
+        if (obj[key]) {
+          failuresSamples.push({ variable, error: obj[key] });
+          testSummaryResults.push({ variable, status: "fail" });
         } else {
-          traverse(obj[key], currentPath);
+          // initialize the samples that do not have performance results
+          // code editor & notepad
+          if (!result[variable]) {
+            result[variable] = {};
+          }
+          testSummaryResults.push({ variable, status: "pass" });
         }
+      }
+      // collect performance data
+      else if (
+        path.length > 2 &&
+        path.length === (path[0] === "samples" && path[1].startsWith("switch") ? 6 : 5) &&
+        !obj["error"]
+      ) {
+        // remove useless attribute
+        const variable = path.join("-");
+        if (!result[variable]) {
+          result[variable] = {};
+        }
+        if (Array.isArray(obj[key])) {
+          obj[key] = obj[key].join(", ");
+        }
+        result[variable][key] = obj[key];
+      }
+      // collect memory data
+      else if (memoryMetrics.includes(key) && !obj["error"]) {
+        // remove useless attribute
+        const variable = path.slice(0, -1).join("-");
+        if (!memoryConsumptionData[variable]) {
+          memoryConsumptionData[variable] = {};
+        }
+        memoryConsumptionData[variable][key] = obj[key];
+      } else {
+        traverse(obj[key], [...path, key], result);
       }
     }
   }
 
-  traverse(data);
+  let samples = {};
+  let developerPreview = {};
+  traverse(data.samples, ["samples"], samples);
+  traverse(data.developerPreview, ["developerPreview"], developerPreview);
 
-  const deviceInfoRows = deviceInfo
-    .map(
-      ({ category, detail }) =>
-        `<tr><td style="border: 1px solid black;">${category}</td><td style="border: 1px solid black;">${detail}</td></tr>`
-    )
-    .join("");
-
-  let performanceDataRows = "";
-  for (const variable in performanceData) {
-    const item = performanceData[variable];
-    performanceDataRows += `<tr><td style="border: 1px solid black;">${variable}</td>`;
-    metrics.forEach((metric) => {
-      if (item[metric]) {
-        performanceDataRows += `<td style="border: 1px solid black;">${item[metric].toString().replace(/,/g, " | ")}</td>`;
-      } else {
-        performanceDataRows += `<td style="border: 1px solid black; text-align:center">-</td>`;
-      }
-    });
-    performanceDataRows += "</tr>";
-  }
-
-  let memoryDataRows = "";
-  for (const variable in memoryConsumptionData) {
-    const item = memoryConsumptionData[variable];
-    memoryDataRows += `<tr><td style="border: 1px solid black;">${variable}</td>`;
-    memoryMetrics.forEach((metric) => {
-      if (item[metric]) {
-        memoryDataRows += `<td style="border: 1px solid black;">${(item[metric] / 1024 ** 3).toFixed(3)} </td>`;
-      } else {
-        memoryDataRows += `<td style="border: 1px solid black; text-align:center">-</td>`;
-      }
-    });
-    memoryDataRows += "</tr>";
-  }
-
-  const failureTableRows = failuresSamples
-    .map(
-      ({ variable, error }) =>
-        `<tr><td style="border: 1px solid black;">${variable}</td><td style="border: 1px solid black;">${error}</td></tr>`
-    )
-    .join("");
-
-  resultObj.html.deviceInfoTable =
-    deviceInfo.length > 0
-      ? `
-        <table style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-          <thead>
-            <tr>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196);
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Category
-              </th>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196); 
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Details
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            ${deviceInfoRows}
-          </tbody>
-        </table>
-        `
-      : null;
-
-  resultObj.html.performanceDataTable =
-    Object.keys(performanceData).length > 0
-      ? `
-        <table style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-          <thead>
-            <tr>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196);
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Sample Case
-              </th>
-            ${metrics
-              .map(
-                (metric) => `
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196);
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-              ${
-                metric !== "tokensPerSecond" && metric !== "throughput" && !metric.startsWith("memory")
-                  ? `${metric} (ms)`
-                  : metric === "throughput"
-                    ? `${metric} (FPS)`
-                    : metric
-              } 
-              </th>`
-              )
-              .join("")}
-            </tr>
-          </thead>
-          <tbody>
-            ${performanceDataRows}
-          </tbody>
-        </table>
-        `
-      : null;
-
-  resultObj.html.memoryDataTable =
-    Object.keys(memoryConsumptionData).length > 0
-      ? `
-        <table style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-          <thead>
-            <tr>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196);
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Sample Case
-              </th>
-            ${memoryMetrics
-              .map(
-                (metric) => `
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196);
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-              ${metric} (GB)
-              </th>`
-              )
-              .join("")}
-            </tr>
-          </thead>
-          <tbody>
-            ${memoryDataRows}
-          </tbody>
-        </table>
-        `
-      : null;
-
-  resultObj.html.failuresTable =
-    failuresSamples.length > 0
-      ? `
-        <table style="border-collapse: collapse; width: 100%; table-layout: fixed;">
-          <thead>
-            <tr>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196); 
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Failed Cases
-              </th>
-              <th style="
-                border: 1px solid black; 
-                padding: 0 4px 0 4px;
-                background-color:rgb(4,116,196); 
-                text-align: center; 
-                vertical-align: middle; 
-                color:white
-              ">
-                Error Details
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            ${failureTableRows}
-          </tbody>
-        </table>
-        `
-      : null;
-
-  resultObj.html.total = totalCaseCount;
-  resultObj.html.failed = failuresSamples.length;
-
-  // Construct table for md
-  const escapeMarkdown = (text) => text.replace(/([\\`*_\[\]()#+\-.!|])/g, "\\$1");
-
-  const deviceInfoMdTableHeaders = ["Category", "Details"];
-  const deviceInfoMdTableRows = deviceInfo.map(({ category, detail }) => [escapeMarkdown(category), detail]);
-
-  resultObj.md.deviceInfoMdTable =
-    deviceInfo.length > 0
-      ? `
-| ${deviceInfoMdTableHeaders.join(" | ")} |
-| ${deviceInfoMdTableHeaders.map(() => "---").join(" | ")} |
-${deviceInfoMdTableRows.map((row) => `| ${row.join(" | ")} |`).join("\n")}
-`.trim()
-      : "";
-
-  const performanceMdTableHeaders = ["Sample Case", ...metrics.map((metric) => `${metric} (ms)`)];
-  const performanceMdTableRows = Object.entries(performanceData).map(([variable, item]) => {
-    const row = [escapeMarkdown(variable)];
-    metrics.forEach((metric) => {
-      row.push(item[metric] ? escapeMarkdown(item[metric].toString().replace(/,/g, " | ")) : "-");
-    });
-    return row;
+  return new Liquid({
+    root: path.resolve(__dirname, '../views'),
+  }).renderFile("mail.liquid", {
+    header: env.emailService.header,
+    failed: failuresSamples.length,
+    total: totalCaseCount,
+    failedCases: failuresSamples,
+    deviceInfo: data.deviceInfo,
+    samples,
+    developerPreview,
+    memory: memoryConsumptionData,
+    footer: env.emailService.footer,
+    signature: env.emailService.signature ?? "WebNN Team",
   });
-
-  resultObj.md.performanceDataMdTable =
-    Object.keys(performanceData).length > 0
-      ? `
-| ${performanceMdTableHeaders.join(" | ")} |
-| ${performanceMdTableHeaders.map(() => "---").join(" | ")} |
-${performanceMdTableRows.map((row) => `| ${row.join(" | ")} |`).join("\n")}
-`.trim()
-      : "";
-
-  const failuresMdTableHeaders = ["Failed Cases", "Error Details"];
-  const failuresMdTableRows = failuresSamples.map(({ variable, error }) => [escapeMarkdown(variable), error]);
-
-  resultObj.md.failuresMdTable =
-    failuresSamples.length > 0
-      ? `
-| ${failuresMdTableHeaders.join(" | ")} |
-| ${failuresMdTableHeaders.map(() => "---").join(" | ")} |
-${failuresMdTableRows.map((row) => `| ${row.join(" | ")} |`).join("\n")}
-`.trim()
-      : "";
-
-  const memoryMdTableHeaders = ["Sample Case", ...memoryMetrics.map((metric) => `${metric} (GB)`)];
-
-  const memoryMdTableRows = Object.entries(memoryConsumptionData).map(([variable, item]) => {
-    const row = [escapeMarkdown(variable)];
-    memoryMetrics.forEach((metric) => {
-      row.push(item[metric] ? (item[metric] / 1024 ** 3).toFixed(3) : "-");
-    });
-    return row;
-  });
-
-  resultObj.md.memoryDataMdTable =
-    Object.keys(memoryConsumptionData).length > 0
-      ? `
-| ${memoryMdTableHeaders.join(" | ")} |
-| ${memoryMdTableHeaders.map(() => "---").join(" | ")} |
-${memoryMdTableRows.map((row) => `| ${row.join(" | ")} |`).join("\n")}
-`.trim()
-      : "";
-
-  const testSummaryMdTableHeaders = ["Sample Case", "Status"];
-  const testSummaryMdTableRows = testSummaryResults.map(({ variable, status }) => [
-    escapeMarkdown(variable),
-    status === "pass" ? "✅" : "❌"
-  ]);
-
-  resultObj.md.testSummaryMdTable =
-    testSummaryResults.length > 0
-      ? `
-| ${testSummaryMdTableHeaders.join(" | ")} |
-| ${testSummaryMdTableHeaders.map(() => "---").join(" | ")} |
-${testSummaryMdTableRows.map((row) => `| ${row.join(" | ")} |`).join("\n")}
-`.trim()
-      : "";
-
-  resultObj.md.total = totalCaseCount;
-  resultObj.md.failed = failuresSamples.length;
-
-  return resultObj;
 }
 
 async function sendMail(subject, filePath) {
   let transporter = nodemailer.createTransport(env.emailService.serverConfig);
-
   try {
-    const jsonFileExists = fs.existsSync(filePath);
-    const jsonFile = jsonFileExists ? fs.readFileSync(filePath, "utf8") : null;
-
+    const result = fs.readFileSync(filePath, "utf8");
     let mailOptions = {
       from: env.emailService.from,
       to: env.emailService.to,
-      subject: subject
-    };
-
-    let htmlContent = `
-      <p><strong>Test completed, please check the details below:</strong></p>
-    `;
-
-    if (jsonFileExists) {
-      mailOptions.attachments = [
+      subject: subject,
+      html: await renderResultsAsHTML(result),
+      attachments: [
         {
           filename: "test-results.json",
-          content: jsonFile
+          content: result
         }
-      ];
-
-      const jsonData = JSON.parse(jsonFile);
-
-      const { total, failed, performanceDataTable, deviceInfoTable, memoryDataTable, failuresTable } =
-        formatResultsAsHTMLTable(jsonData).html;
-
-      if (failuresTable) {
-        htmlContent += `
-          <p><strong>Test Summary (Failed / Total) : ${failed}/ ${total}  </strong></p>
-          ${failuresTable}
-        `;
-      } else {
-        htmlContent += `
-        <p><strong> All ${total} sample tests success.</strong></p>`;
-      }
-
-      if (deviceInfoTable) {
-        htmlContent += `<p><strong>Device Info</strong></p>
-          ${deviceInfoTable}`;
-      }
-
-      if (performanceDataTable) {
-        htmlContent += `<p><strong>Performance Metric</strong></p>
-        ${performanceDataTable}`;
-      }
-
-      if (memoryDataTable) {
-        htmlContent += `<p><strong>Memory Consumption</strong></p>
-        ${memoryDataTable}`;
-      }
-    }
-
-    htmlContent += `
-      <p>See trends at: 
-        <a href="http://webrtc33.sh.intel.com/WebNN/sample/trends.html" style="color: blue; text-decoration: underline;">
-          WebNN Test Trends
-        </a>
-      </p>
-      <p>Thanks,<br>WebNN Team</p>
-    `;
-
-    mailOptions.html = htmlContent;
-
+      ]
+    };
     await transporter.verify();
     await transporter.sendMail(mailOptions);
   } catch (error) {
@@ -500,73 +149,8 @@ async function scpUpload(file) {
   }
 }
 
-function generateTestSummaryMd(filePath) {
-  const jsonFileExists = fs.existsSync(filePath);
-  const jsonFile = jsonFileExists ? fs.readFileSync(filePath, "utf8") : null;
-  const jsonData = JSON.parse(jsonFile);
-  const {
-    total,
-    failed,
-    deviceInfoMdTable,
-    performanceDataMdTable,
-    memoryDataMdTable,
-    failuresMdTable,
-    testSummaryMdTable
-  } = formatResultsAsHTMLTable(jsonData).md;
-
-  const markdownContent = `
-${
-  testSummaryMdTable
-    ? `#### Test Summary (Success / Total): ${total - failed} / ${total}
-${testSummaryMdTable}
-
----
-`
-    : ``
-}
-
-${
-  deviceInfoMdTable
-    ? `#### Device Info
-${deviceInfoMdTable}
-
----
-`
-    : ``
-}
-
-${
-  performanceDataMdTable
-    ? `#### Performance Metrics
-${performanceDataMdTable}
-
----
-`
-    : ``
-}
-
-${
-  memoryDataMdTable
-    ? `#### Memory Consumption
-${memoryDataMdTable}
-
----
-`
-    : ``
-}
-
-${
-  failuresMdTable
-    ? `#### Failures
-${failuresMdTable}`
-    : ``
-}`;
-  const outputPath = filePath.replace(path.extname(filePath), ".md");
-  fs.writeFileSync(outputPath, markdownContent.trim());
-}
-
 module.exports = {
   report,
   scpUpload,
-  generateTestSummaryMd
+  renderResultsAsHTML
 };

--- a/src/views/mail.liquid
+++ b/src/views/mail.liquid
@@ -1,0 +1,156 @@
+<style>
+    table {
+        border-collapse: collapse;
+    }
+
+    th {
+        background-color: rgb(4, 116, 196);
+        color: white;
+    }
+
+    th, td {
+        border: 1px solid black;
+        padding: 0 6px;
+    }
+
+    table.number-data td {
+        text-align: right;
+    }
+
+    table.number-data td:first-child {
+        text-align: left;
+    }
+</style>
+
+<p>{{ header }}</p>
+
+<p>Test Summary (Failed / Total): {{ failed }} / {{ total }}</p>
+
+{% if failedCases %}
+    <table>
+        <thead>
+        <tr>
+            <th>Test Case</th>
+            <th>Error</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for case in failedCases %}
+            <tr>
+                <td>{{ case.variable }}</td>
+                <td>{{ case.error }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if deviceInfo %}
+    <h3>Device Information</h3>
+    <table>
+        <thead>
+        <tr>
+            <th>Category</th>
+            <th>Details</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for info in deviceInfo %}
+            <tr>
+                <td>{{ info[0] }}</td>
+                <td>{{ info[1] }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if samples %}
+    <h3>Performance of WebNN Samples</h3>
+    <table class="number-data">
+        <thead>
+        <tr>
+            <th>Demo</th>
+            <th>Inference<br>Time (ms)</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for sample in samples %}
+            <tr>
+                <td>{{ sample[0] }}</td>
+                <td>{{ sample[1].inferenceTime }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if developerPreview %}
+    <h3>Performance of WebNN Developer Preview</h3>
+    <table class="number-data">
+        <thead>
+        <tr>
+            <th>Demo</th>
+            <th>First<br>(ms)</th>
+            <th>Average<br>(ms)</th>
+            <th>Median<br>(ms)</th>
+            <th>Best<br>(ms)</th>
+            <th>Throughput<br>(FPS)</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for sample in developerPreview %}
+            <tr>
+                <td>{{ sample[0] }}</td>
+                <td>{{ sample[1].first }}</td>
+                <td>{{ sample[1].average }}</td>
+                <td>{{ sample[1].median }}</td>
+                <td>{{ sample[1].best }}</td>
+                <td>{{ sample[1].throughput }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if memory %}
+    <h3>Memory Consumption</h3>
+    <table class="number-data">
+        <thead>
+        <tr>
+            <th rowspan="3">Demo</th>
+            <th colspan="6">Private Memory (GB)</th>
+        </tr>
+        <tr>
+            <th colspan="3">Renderer</th>
+            <th colspan="3">GPU</th>
+        </tr>
+        <tr>
+            <th>before</th>
+            <th>after</th>
+            <th>peak</th>
+            <th>before</th>
+            <th>after</th>
+            <th>peak</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% assign gigabytes = 1073741824 %}
+        {% for sample in memory %}
+            <tr>
+                <td>{{ sample[0] }}</td>
+                <td>{{ sample[1].privateMemoryRendererBefore | divided_by: gigabytes | round: 3 }}</td>
+                <td>{{ sample[1].privateMemoryRendererAfter | divided_by: gigabytes | round: 3 }}</td>
+                <td>{{ sample[1].privateMemoryRendererPeak | divided_by: gigabytes | round: 3 }}</td>
+                <td>{{ sample[1].privateMemoryGpuBefore | divided_by: gigabytes | round: 3 }}</td>
+                <td>{{ sample[1].privateMemoryGpuAfter | divided_by: gigabytes | round: 3 }}</td>
+                <td>{{ sample[1].privateMemoryGpuPeak | divided_by: gigabytes | round: 3 }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+<p>{{ footer }}</p>
+
+<p>Thanks,<br>{{ signature }}</p>


### PR DESCRIPTION
@ibelem This PR:
- Use liquidjs html template language to better format html for email notification
- Split the performance table so that the unnecessary cell is not shown
- Extract table cell styles into a <style> tag
- Move some hard coded information into env.json
- Removed markdown report output, use rendered html instead
- Minor code optimizations