### PR TITLE
Fix the bug that the test result is not shown in the email

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -125,7 +125,7 @@ const main = async () => {
     console.log(`Test results have been saved to ${jsonPath} and ${htmlPath}`);
 
     if (env.env === "production") {
-      await report(jsonPath);
+      await report(results);
       await scpUpload(jsonPath);
     }
   } catch (error) {


### PR DESCRIPTION
@ibelem This PR fixes the bug that no result is shown in the report email
- Passing result object instead of string to renderResultsAsHTML()
- Reworked sendMail() function signature
- Use detailed attachment name
- Code style and error message fixes