### PR TITLE
Show full CPU name

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -320,14 +320,7 @@ async function getConfig() {
 
   // CPU
   const cpuData = await si.cpu();
-  let cpuName = cpuData.brand;
-  const cpuManufacturer = cpuData.manufacturer;
-  if (cpuManufacturer.includes("Intel")) {
-    cpuName = cpuName.split(" ").pop();
-  } else if (cpuManufacturer.includes("AMD")) {
-    cpuName = cpuName.split(" ").slice(0, 3).join(" ");
-  }
-  deviceInfo["cpuName"] = cpuName;
+  deviceInfo["cpuName"] = cpuData.brand;
 
   // GPU
   try {


### PR DESCRIPTION
The brand attributes of CPUs across generations are not in same format. On some platform we get a 2.20GHz...
<img width="296" height="30" alt="image" src="https://github.com/user-attachments/assets/22074ae2-245f-440d-9bb3-022bc39a3e71" />

This CL make it show full CPU name instead.