### PR TITLE
Use retry options in rmSync()

### DIFF
--- a/generate-config.js
+++ b/generate-config.js
@@ -54,7 +54,7 @@ function filterSamplesWithDevices(config, devices) {
 // chrome_canary & cpu, npu, gpu by default
 const ORIGINAL_CONFIG = {
   browser: "chrome_canary",
-  browserArgs: ["--start-maximized", "--noerrdialogs"],
+  browserArgs: ["--start-maximized"],
   browserArgsWebnn: ["--enable-features=WebMachineLearningNeuralNetwork,WebNNOnnxRuntime"],
   browserUserData: true,
   browserUserDataPath: "",

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -47,9 +47,7 @@ function getBrowserPath(browser) {
     userDataDir = config.browserUserDataPath;
   } else {
     userDataDir = path.join(os.tmpdir(), `webnn-sample-test-${browser}`);
-    if (fs.existsSync(userDataDir)) {
-      fs.rmSync(userDataDir, { recursive: true, force: true });
-    }
+    fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 5 });
     fs.mkdirSync(userDataDir, { recursive: true });
   }
 


### PR DESCRIPTION
This CL uses rmSync() with retry option to avoid error in removing crashpad file in user data dir.