### PR TITLE
Return error early

### DIFF
--- a/src/cases/samples/face-recognition.js
+++ b/src/cases/samples/face-recognition.js
@@ -63,14 +63,10 @@ async function faceRecognitionTest({ backend, dataType, model } = {}) {
       }
 
       // wait for model running results
-      try {
-        await page.waitForSelector(pageElement["computeTime"], {
-          visible: true
-        });
-      } catch (error) {
-        errorMsg += `[PageTimeout]`;
-        throw error;
-      }
+      await Promise.race([
+        page.waitForSelector(pageElement["computeTime"], { visible: true }),
+        util.throwErrorOnElement(page, pageElement.alertWarning)
+      ]);
 
       // get results
       const computeTime = await page.$eval(pageElement["computeTime"], (el) => el.textContent);
@@ -125,7 +121,6 @@ async function faceRecognitionTest({ backend, dataType, model } = {}) {
       errorMsg += error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
       }
       console.warn(errorMsg);
     } finally {

--- a/src/cases/samples/facial-landmark-detection.js
+++ b/src/cases/samples/facial-landmark-detection.js
@@ -60,14 +60,10 @@ async function facialLandmarkDetectionTest({ backend, dataType, model } = {}) {
       }
 
       // wait for model running results
-      try {
-        await page.waitForSelector(pageElement["computeTime"], {
-          visible: true
-        });
-      } catch (error) {
-        errorMsg += `[PageTimeout]`;
-        throw error;
-      }
+      await Promise.race([
+        page.waitForSelector(pageElement["computeTime"], { visible: true }),
+        util.throwErrorOnElement(page, pageElement.alertWarning)
+      ]);
 
       const computeTime = await page.$eval(pageElement["computeTime"], (el) => el.textContent);
 
@@ -106,7 +102,6 @@ async function facialLandmarkDetectionTest({ backend, dataType, model } = {}) {
       errorMsg = error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
       }
       console.warn(errorMsg);
     } finally {

--- a/src/cases/samples/fast-style-transfer.js
+++ b/src/cases/samples/fast-style-transfer.js
@@ -51,14 +51,10 @@ async function fastStyleTransferTest({ backend, dataType, model } = {}) {
           await util.clickElementIfEnabled(page, selector);
         }
 
-        try {
-          await page.waitForSelector(pageElement["computeTime"], {
-            visible: true
-          });
-        } catch (error) {
-          errorMsg += `[PageTimeout]`;
-          throw error;
-        }
+        await Promise.race([
+          page.waitForSelector(pageElement["computeTime"], { visible: true }),
+          util.throwErrorOnElement(page, pageElement.alertWarning)
+        ]);
 
         const computeTime = await page.$eval(pageElement["computeTime"], (el) => el.textContent);
 
@@ -115,7 +111,6 @@ async function fastStyleTransferTest({ backend, dataType, model } = {}) {
       errorMsg = error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
       }
       console.warn(errorMsg);
     } finally {

--- a/src/cases/samples/notepad.js
+++ b/src/cases/samples/notepad.js
@@ -46,20 +46,16 @@ async function notepadTest({ backend, dataType, model } = {}) {
       await page.goto(`${config["samplesBasicUrl"]}${config["samplesUrl"][sample]}`, {
         waitUntil: "networkidle0"
       });
-      try {
-        // wait for select element display
-        await page.waitForSelector(pageElement["deviceTypeSelect"]);
-        await page.click(pageElement["deviceTypeSelect"]);
-        // wait for option
-        await page.waitForSelector(`${pageElement["deviceTypeSelect"]} option`);
-        // choose option
-        await page.select("select", backend);
-        // wait for results display
-        await util.delay(5000);
-        await page.waitForSelector(pageElement["outputText"]);
-      } catch (error) {
-        throw error;
-      }
+      // wait for select element display
+      await page.waitForSelector(pageElement["deviceTypeSelect"]);
+      await page.click(pageElement["deviceTypeSelect"]);
+      // wait for option
+      await page.waitForSelector(`${pageElement["deviceTypeSelect"]} option`);
+      // choose option
+      await page.select("select", backend);
+      // wait for results display
+      await util.delay(5000);
+      await page.waitForSelector(pageElement["outputText"]);
 
       // get console results
       const actualValue = await page.$eval(pageElement["outputText"], (el) => el.innerHTML);
@@ -81,7 +77,7 @@ async function notepadTest({ backend, dataType, model } = {}) {
       errorMsg = error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
+        errorMsg += await util.getAlertWarning(page, pageElement.alertWarning);
       }
       console.warn(errorMsg);
     } finally {

--- a/src/cases/samples/object-detection.js
+++ b/src/cases/samples/object-detection.js
@@ -58,31 +58,21 @@ async function objectDetectionTest({ backend, dataType, model } = {}) {
       }
 
       // wait for model running results
-      try {
-        await page.waitForSelector(pageElement["computeTime"], {
-          visible: true
-        });
-      } catch (error) {
-        throw error;
-      }
+      await page.waitForSelector(pageElement["computeTime"], { visible: true });
 
       // save canvas image
       let compareImagesResults = 0;
-      try {
-        const canvasImageName = `${sample}_${dataType}_${model}`;
-        const saveCanvasResult = await util.saveCanvasImage(page, pageElement.objectDetectionCanvas, canvasImageName);
+      const canvasImageName = `${sample}_${dataType}_${model}`;
+      const saveCanvasResult = await util.saveCanvasImage(page, pageElement.objectDetectionCanvas, canvasImageName);
 
-        // compare canvas to expected canvas
-        const expectedCanvasPath = `${expectedCanvas}/${sample}_${model}.png`;
-        compareImagesResults = util.compareImages(saveCanvasResult.canvasPath, expectedCanvasPath);
+      // compare canvas to expected canvas
+      const expectedCanvasPath = `${expectedCanvas}/${sample}_${model}.png`;
+      compareImagesResults = util.compareImages(saveCanvasResult.canvasPath, expectedCanvasPath);
 
-        console.log("Compare images results with the template image:", compareImagesResults);
+      console.log("Compare images results with the template image:", compareImagesResults);
 
-        if (compareImagesResults < 95) {
-          errorMsg += "Image result is not the same as template, please check saved images.";
-        }
-      } catch (error) {
-        throw error;
+      if (compareImagesResults < 95) {
+        errorMsg += "Image result is not the same as template, please check saved images.";
       }
 
       // get results
@@ -109,7 +99,7 @@ async function objectDetectionTest({ backend, dataType, model } = {}) {
       errorMsg = error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
+        errorMsg += await util.getAlertWarning(page, pageElement.alertWarning);
       }
       console.warn(errorMsg);
     } finally {

--- a/src/cases/samples/switch-backend.js
+++ b/src/cases/samples/switch-backend.js
@@ -11,7 +11,7 @@ async function switchBackendTest() {
   let source = "samples";
   let sample = "switchBackendTest";
 
-  // get the first sub sample and only test this one
+  // get the first subsample and only test this one
   const subSample = Object.keys(config[source][sample].samples)[0];
   const testRounds = config[source][sample]["rounds"];
 
@@ -22,7 +22,6 @@ async function switchBackendTest() {
 
     const screenshotFilename = `${source}_${sample}_${subSample}_${backend}_${dataType}_${model}_round${index}`;
     let subSampleResults = {};
-    let errorMsg = "";
 
     try {
       const elementsToClick = [pageElement[backend], pageElement[dataType], pageElement[model]];
@@ -63,28 +62,23 @@ async function switchBackendTest() {
           probability1: prob1,
           label2: label2,
           probability2: prob2,
-          error: errorMsg
         };
 
         pageResults = util.replaceEmptyData(pageResults);
         _.set(subSampleResults, [subSample, backend, dataType, model, "inferenceTime"], pageResults.inferenceTime);
-        _.set(subSampleResults, [subSample, backend, dataType, model, "error"], pageResults.errorMsg);
       }
     } catch (error) {
-      errorMsg += error.message;
       if (page) {
         await util.saveScreenshot(page, screenshotFilename);
-        errorMsg += await util.getAlertWarning(page, pageElement.alertWaring);
       }
-      console.warn(errorMsg);
-    } finally {
+      console.warn(error.message);
       _.set(
         subSampleResults,
         [subSample, backend, dataType, model, "error"],
-        errorMsg.substring(0, config.errorMsgMaxLength)
+        error.message.substring(0, config.errorMsgMaxLength)
       );
-      return subSampleResults;
     }
+    return subSampleResults;
   };
 
   // set browser args, browser path

--- a/src/page-elements/samples.js
+++ b/src/page-elements/samples.js
@@ -1,6 +1,6 @@
 const pageElement = {
   // public element
-  alertWaring: ".alert-warning > span", // css selector
+  alertWarning: ".alert-warning > span", // css selector
   // model load result
   loadTime: "#loadTime",
   buildTime: "#buildTime",

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -84,7 +84,13 @@ function getBrowserPath(browser) {
       baseDir = process.env.PROGRAMFILES;
     }
     browserExeName = browser.includes("chrome") ? "chrome.exe" : "msedge.exe";
-    browserPath = path.join(baseDir, browser.includes("edge") ? "Microsoft" : "Google", browserName, "Application", browserExeName);
+    browserPath = path.join(
+      baseDir,
+      browser.includes("edge") ? "Microsoft" : "Google",
+      browserName,
+      "Application",
+      browserExeName
+    );
   } else if (deviceInfo.platform === "linux") {
     browserExeName = browserName;
     browserPath = path.join("/usr/bin", browserExeName);
@@ -252,6 +258,27 @@ async function getAlertWarning(page, alertLocation) {
   }
 }
 
+async function throwErrorOnElement(page, element) {
+  await page.waitForSelector(element, { visible: true });
+  const error = await page.$eval(element, (el) => el.textContent);
+  throw Error(error);
+}
+
+async function throwOnDevelopmentPreviewError(page, element) {
+  await page.waitForFunction(
+    (selector) => document.querySelector(selector).textContent !== "WebNN supported",
+    {},
+    element
+  );
+  throw Error(await page.$eval(element, (el) => el.textContent));
+}
+
+async function throwOnUncaughtException(page) {
+  return new Promise((resolve, reject) => {
+    page.on("pageerror", reject);
+  });
+}
+
 // judge element classlist has "disabled" value
 async function judgeElementClickable(page, pageElement, parent = false) {
   let isDisabled = false;
@@ -409,11 +436,12 @@ async function getConfig() {
       const info = execSync(`powershell -Command "${command.replace(/\n+/g, " ")}"`)
         .toString()
         .trim();
-
-      const npuInfo = JSON.parse(info);
-      deviceInfo["npuName"] = npuInfo["DeviceName"];
-      deviceInfo["npuManufacturer"] = npuInfo["Manufacturer"];
-      deviceInfo["npuDriverVersion"] = npuInfo["DriverVersion"];
+      if (info) {
+        const npuInfo = JSON.parse(info);
+        deviceInfo["npuName"] = npuInfo["DeviceName"];
+        deviceInfo["npuManufacturer"] = npuInfo["Manufacturer"];
+        deviceInfo["npuDriverVersion"] = npuInfo["DriverVersion"];
+      }
     }
   } catch (error) {
     console.error(`Error occurred while getting NPU info\n. Error Details: ${error}`);
@@ -701,6 +729,9 @@ module.exports = {
   replaceEmptyData,
   saveScreenshot,
   getAlertWarning,
+  throwErrorOnElement,
+  throwOnDevelopmentPreviewError,
+  throwOnUncaughtException,
   getConfig,
   saveCanvasImage,
   compareImages,


### PR DESCRIPTION
This CL detects and wait for the error message is shown so that we return right after the error occurred, instead of waiting until timeouts. This makes testing and debugging faster.