### PR TITLE
Don't use CPU in developer-preview image-classification switch backend test

### DIFF
--- a/src/cases/developer-preview/image-classification.js
+++ b/src/cases/developer-preview/image-classification.js
@@ -167,7 +167,7 @@ async function imageClassificationPreviewTest({ backend, dataType, model } = {})
       });
 
       for (let _backend in config[source][sample]) {
-        if (!["cpu", "gpu", "npu"].includes(_backend)) continue;
+        if (![/* no cpu button */ "gpu", "npu"].includes(_backend)) continue;
         for (let _dataType in config[source][sample][_backend]) {
           for (let _model of config[source][sample][_backend][_dataType]) {
             console.log(`${type} ${source} ${sample} ${_backend} ${_dataType} ${_model} testing...`);


### PR DESCRIPTION
@ibelem The [developer-preview image-classification](https://microsoft.github.io/webnn-developer-preview/demos/image-classification/) don't have `WebNN CPU` button. This CL removes cpu backend in switch-backend test to avoid errors.