### PR TITLE
Allow filters without model name

### DIFF
--- a/src/cases/developer-preview/segment-anything.js
+++ b/src/cases/developer-preview/segment-anything.js
@@ -81,7 +81,7 @@ async function segmentAnythingTest({ config, backend, dataType, model } = {}) {
   };
 
   let results = {};
-  if (backend && dataType && model) {
+  if (backend && dataType) {
     _.set(results, [sample, backend, dataType], await testExecution(backend, dataType, model));
   } else {
     for (let _backend in config[source][sample]) {

--- a/src/cases/developer-preview/stable-diffusion-1-5.js
+++ b/src/cases/developer-preview/stable-diffusion-1-5.js
@@ -143,7 +143,7 @@ async function stableDiffusion15Test({ config, backend, dataType, model } = {}) 
     }
   };
 
-  if (backend && dataType && model) {
+  if (backend && dataType) {
     await testExecution(backend, dataType, model);
   } else {
     for (let _backend in config[source][sample]) {

--- a/src/cases/developer-preview/stable-diffusion-turbo.js
+++ b/src/cases/developer-preview/stable-diffusion-turbo.js
@@ -220,7 +220,7 @@ async function stableDiffusionTurboTest({ config, backend, dataType, model } = {
     }
   };
 
-  if (backend && dataType && model) {
+  if (backend && dataType) {
     await testExecution(backend, dataType, model);
   } else {
     for (let _backend in config[source][sample]) {

--- a/src/cases/developer-preview/whisper-base.js
+++ b/src/cases/developer-preview/whisper-base.js
@@ -136,7 +136,7 @@ async function whisperBaseTest({ config, backend, dataType, model } = {}) {
     }
   };
 
-  if (backend && dataType && model) {
+  if (backend && dataType) {
     await testExecution(backend, dataType, model);
   } else {
     for (let _backend in config[source][sample]) {


### PR DESCRIPTION
Some demos run all sub-models in a sequence. Removing unnecessary model name filter.