### PR TITLE
Add the argument "--disable_webnn_for_npu=0"

### DIFF
--- a/generate-config.js
+++ b/generate-config.js
@@ -325,7 +325,10 @@ program
 
     const config = { backend, browser, ...filterSamplesWithDevices(ORIGINAL_CONFIG, devices) };
     if (backend === "ort") {
-      config.browserArgs.push("--enable-features=WebMachineLearningNeuralNetwork,WebNNOnnxRuntime");
+      config.browserArgs.push(
+        "--enable-features=WebMachineLearningNeuralNetwork,WebNNOnnxRuntime",
+        "--disable_webnn_for_npu=0"
+      );
     } else if (backend === "tflite") {
       config.browserArgs.push(
         "--enable-features=WebMachineLearningNeuralNetwork",
@@ -337,7 +340,8 @@ program
         "--enable-features=WebNNOnnxRuntime,WebMachineLearningNeuralNetwork",
         `--webnn-ort-library-path-for-testing=${onnxruntimeProvidersPath}`,
         `--webnn-ort-ep-library-path-for-testing=OpenVINOExecutionProvider?${onnxruntimeProvidersPath}\\onnxruntime_providers_openvino_plugin.dll`,
-        "--allow-third-party-modules"
+        "--allow-third-party-modules",
+        "--disable_webnn_for_npu=0"
       );
     }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -313,9 +313,9 @@ async function getNPUInfo() {
     // Currently supports fetching Intel NPU (AI Boost) device information on Windows platforms,
     // other NPU manufacturers support will be added in the future.
     const command = `
-        Get-WmiObject Win32_PnPSignedDriver | 
-        Where-Object { $_.DeviceName -match 'Intel\\(R\\) AI Boost' } | 
-        Select-Object DeviceName, DriverVersion, Manufacturer | 
+        Get-WmiObject Win32_PnPSignedDriver |
+        Where-Object { $_.DeviceName -match 'Intel\\(R\\) (AI Boost|NPU)' } |
+        Select-Object DeviceName, DriverVersion, Manufacturer |
         ConvertTo-Json -Depth 3`;
     const info = execSync(`powershell -Command "${command.replace(/\n+/g, " ")}"`)
       .toString()


### PR DESCRIPTION
@ibelem I am merging old changes.
This CL adds `--disable_webnn_for_npu=0` to avoid NPU being disabled by driver workarounds.
Also update the filter to support NPU from more vendors.