### PR TITLE
Clean the user data dir once only

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,9 +64,15 @@ program.action(async ({ config: configPath, filters, browserDir, userDataDir }) 
     }
   }
 
+  util.killBrowserProcess(config);
   config.browserAppPath = browserDir ?? config.browserAppPath;
   config.browserUserDataPath = userDataDir ?? config.browserUserDataPath;
-  util.killBrowserProcess(config);
+  // If the user data dir is not overridden by CLI, clean up the default temporary user data dir before the tests
+  if (!(config.browserUserData && config.browserUserDataPath)) {
+    const userDataDir = util.getBrowserPath(config).userDataDir;
+    fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 5000 });
+    fs.mkdirSync(userDataDir, { recursive: true });
+  }
 
   const results = {
     deviceInfo: await util.getDeviceInfo(config),

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -42,8 +42,6 @@ function getBrowserPath(config) {
     userDataDir = config.browserUserDataPath;
   } else {
     userDataDir = path.join(os.tmpdir(), `webnn-sample-test-${browser}`);
-    fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 5 });
-    fs.mkdirSync(userDataDir, { recursive: true });
   }
 
   const browserConfig = {
@@ -650,6 +648,7 @@ module.exports = {
   waitForElementEnabled,
   killBrowserProcess,
   getBrowserProcess,
+  getBrowserPath,
   chromePath,
   clickElementIfEnabled,
   generateSupportedSamplesArray,


### PR DESCRIPTION
@ibelem This PR clears the user data dir only once before all tests, instead of each test cases, to speedup testing.