### PR TITLE
Refactor report table

### DIFF
--- a/src/cases/developer-preview/whisper-base.js
+++ b/src/cases/developer-preview/whisper-base.js
@@ -48,10 +48,7 @@ class WhisperBase extends DeveloperPreviewSample {
 
     console.log(`Test results- realtime:${xRealtime}, timeToFirstToken:${timeToFirstToken} `);
 
-    return ["encoder", "decoder", "decoderKvCache"].reduce((acc, model) => {
-      acc[model] = { tokensPerSecond };
-      return acc;
-    }, {});
+    return { tokensPerSecond };
   }
 }
 

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -35,7 +35,16 @@ async function getDeviceInfo(config) {
     developerPreviewUrl: config.developerPreviewBasicUrl,
     backend: config.backend,
     browser: config.browser,
-    browserArgs: config.browserArgs
+    browserArgs: config.browserArgs.map((arg) => {
+      if (!arg.includes(" ")) return arg;
+      const eqIndex = arg.indexOf("=");
+      if (eqIndex !== -1 && arg.startsWith("--")) {
+        const key = arg.substring(0, eqIndex + 1);
+        const value = arg.substring(eqIndex + 1);
+        return value.includes(" ") ? `${key}"${value}"` : arg;
+      }
+      return `"${arg}"`;
+    })
   };
   const { browserPath, userDataDir } = getBrowserPath(config);
   deviceInfo["browserPath"] = browserPath;

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -12,6 +12,7 @@ const env = util.getEnv();
 async function renderResultsAsHTML(data) {
   const failuresSamples = [];
   const memoryConsumptionData = {};
+  const tokenPerSecondResult = {};
 
   function traverse(obj, path = [], result) {
     for (const key in obj) {
@@ -44,7 +45,12 @@ async function renderResultsAsHTML(data) {
           memoryConsumptionData[variable] = {};
         }
         memoryConsumptionData[variable][key] = obj[key];
-      } else {
+      }
+      // collect tokens per second data
+      else if (key === "tokensPerSecond" && !obj["error"]) {
+        const variable = path.join("-");
+        tokenPerSecondResult[variable] = { tokensPerSecond: obj[key] };
+      } else if (typeof obj[key] === "object" && obj[key] !== null) {
         traverse(obj[key], [...path, key], result);
       }
     }
@@ -54,31 +60,12 @@ async function renderResultsAsHTML(data) {
   traverse({ samples: data.samples, "developer-preview": data["developer-preview"] }, [], result);
   const inferenceTimeResult = Object.fromEntries(Object.entries(result).filter(([_, value]) => value.inferenceTime));
   const firstAverageMedianBestResult = Object.fromEntries(Object.entries(result).filter(([_, value]) => value.average));
-  const tokenPerSecondResult = {};
-  for (let [key, value] of Object.entries(result).filter(([_, value]) => value.tokensPerSecond)) {
-    let prefix = key.split("-").slice(0, -1).join("-");
-    let model = key.split("-").slice(-1)[0];
-    if (!tokenPerSecondResult[prefix]) {
-      tokenPerSecondResult[prefix] = { models: [model], tokensPerSecond: value.tokensPerSecond };
-    } else if (tokenPerSecondResult[prefix].tokensPerSecond !== value.tokensPerSecond) {
-      tokenPerSecondResult[key] = { models: [], tokensPerSecond: value.tokensPerSecond };
-    } else {
-      tokenPerSecondResult[prefix].models.push(model);
-    }
-  }
   let aggregatedFailures = {};
   for (let failure of failuresSamples) {
-    let key = failure.variable.split("-").slice(0, -1).join("-");
-    let model = failure.variable.split("-").slice(-1)[0];
-    if (aggregatedFailures[key]?.error === failure.error) {
-      aggregatedFailures[key].models.push(model);
-    } else {
-      aggregatedFailures[key] = {
-        variable: key,
-        models: [model],
-        error: failure.error
-      };
-    }
+    aggregatedFailures[failure.variable] = {
+      variable: failure.variable,
+      error: failure.error
+    };
   }
 
   const engine = new Liquid({
@@ -94,7 +81,7 @@ async function renderResultsAsHTML(data) {
     .renderFile("mail.liquid", {
       header: env.emailService.header,
       failed: failuresSamples.length,
-      total: Object.entries(result).length + failuresSamples.length,
+      total: Object.entries(result).length + Object.entries(tokenPerSecondResult).length + failuresSamples.length,
       failedCases: Object.values(aggregatedFailures),
       deviceInfo: data.deviceInfo,
       sessionCreate: data.sessionCreate,

--- a/src/views/mail.liquid
+++ b/src/views/mail.liquid
@@ -57,19 +57,13 @@
         <thead>
         <tr>
             <th>Test Case</th>
-            <th>Models</th>
             <th>Error</th>
         </tr>
         </thead>
         <tbody>
         {% for case in failedCases %}
             <tr>
-                {% if case.models.length == 1 %}
-                    <td colspan="2">{{ case.variable }}-{{ case.models | join: ", " }}</td>
-                {% else %}
-                    <td>{{ case.variable }}</td>
-                    <td>{{ case.models | join: ", " }}</td>
-                {% endif %}
+                <td>{{ case.variable }}</td>
                 <td>{{ case.error | split: "\n" | join: "<br>" }}</td>
             </tr>
         {% endfor %}
@@ -81,19 +75,65 @@
 {% if deviceInfo %}
     <h3>Device Information</h3>
     <table>
-        <thead>
-        <tr>
-            <th>Category</th>
-            <th>Details</th>
-        </tr>
-        </thead>
         <tbody>
-        {% for info in deviceInfo %}
+        <tr>
+            <th>Hostname</th>
+            <td>{{ deviceInfo.hostname }}</td>
+            <th>Platform</th>
+            <td>{{ deviceInfo.platform }}</td>
+        </tr>
+        <tr>
+            <th>CPU</th>
+            <td>{{ deviceInfo.cpuName }}</td>
+            <th>RAM</th>
+            <td>{{ deviceInfo.installedMemoryGb }} GB</td>
+        </tr>
+        {% if deviceInfo.gpuName %}
             <tr>
-                <td>{{ info[0] }}</td>
-                <td>{{ info[1] | join: " " }}</td>
+                <th>GPU</th>
+                <td>{{ deviceInfo.gpuName }} ({{ deviceInfo.gpuVendorId }}:{{ deviceInfo.gpuDeviceId }})</td>
+                <th>Driver version</th>
+                <td>{{ deviceInfo.gpuDriverVersion }}</td>
             </tr>
-        {% endfor %}
+        {% endif %}
+        {% if deviceInfo.npuName %}
+            <tr>
+                <th>NPU</th>
+                <td>{{ deviceInfo.npuName }} ({{ deviceInfo.npuManufacturer }})</td>
+                <th>Driver version</th>
+                <td>{{ deviceInfo.npuDriverVersion }}</td>
+            </tr>
+        {% endif %}
+        <tr>
+            <th>Browser</th>
+            <td>{{ deviceInfo.browser }}</td>
+            {% if deviceInfo.chromeVersion %}
+                <th>Chrome version</th>
+                <td>{{ deviceInfo.chromeVersion }}</td>
+            {% else %}
+                <th>Edge version</th>
+                <td>{{ deviceInfo.edgeVersion }}</td>
+            {% endif %}
+        </tr>
+        <tr>
+            <th>Command line</th>
+            <td colspan="3">
+                "{{ deviceInfo.browserPath }}"
+                <span style="font-size: 12px; color: gray">{{ deviceInfo.browserArgs | join: " " }}</span>
+            </td>
+        </tr>
+        <tr>
+            <th>Samples URL</th>
+            <td colspan="3">{{ deviceInfo.samplesUrl }}</td>
+        </tr>
+        <tr>
+            <th>Developer preview URL</th>
+            <td colspan="3">{{ deviceInfo.developerPreviewUrl }}</td>
+        </tr>
+        <tr>
+            <th>Backend</th>
+            <td colspan="3">{{ deviceInfo.backend }}</td>
+        </tr>
         </tbody>
     </table>
     <br>
@@ -184,7 +224,6 @@
         <thead>
         <tr>
             <th>Demo</th>
-            <th>Models</th>
             <th>Tokens<br>Per Second</th>
         </tr>
         </thead>
@@ -193,7 +232,6 @@
             {% if item[1].tokensPerSecond %}
                 <tr>
                     <td>{{ item[0] }}</td>
-                    <td>{{ item[1].models | join: ", " }}</td>
                     <td>{{ item[1].tokensPerSecond }}</td>
                 </tr>
             {% endif %}


### PR DESCRIPTION
@ibelem This PR:
- Refactor report table to a more compact one
- Remove (redundant) model column in report
- Fix bug in rendering results to HTML
- Escape `browserArgs` so that it can be directly copied into command line to reproduce the test